### PR TITLE
Update EntityExtractionWidget for no entities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.3.6
+Version: 1.3.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/entityextractionwidget.R
+++ b/R/entityextractionwidget.R
@@ -33,15 +33,19 @@ EntityExtractionWidget <- function(entity.percentages, variant.percentages, enti
          "<th>Entity</th><th>% (n)</th>",
          "</thead><tbody>")
 
-    if(all(entity.counts == 0)) {
-        if(empty.extraction == "output")
-        {
-            empty.reason <- NULL
-        } else
-        {
+    if(all(entity.counts == 0))
+    {
+        # expect empty.reason to be either "output" or "remove". NA shouldn't occur
+        if(is.na(empty.reason))
+            stop("Unexpected output: Zero entities extracted with no reason specified.")
+        else if(empty.extraction == "output")
+            empty.reason <- ""
+        else if(empty.extraction == "remove")
             empty.reason <- paste0("since the only entities in the output have been removed with the user specified",
                                    " remove entities from extraction settings.")
-        }
+        else
+            stop("Unexpected output: Zero entities extracted with unexpected reason - ", empty.reason)
+
         user.empty.msg <- paste0("No entities found to extract from dataset ", empty.reason, "\n",
                                  "Use the 'Add named entities to extraction' control if you wish ",
                                  "to add entities to extract from the text.")

--- a/R/entityextractionwidget.R
+++ b/R/entityextractionwidget.R
@@ -36,7 +36,7 @@ EntityExtractionWidget <- function(entity.percentages, variant.percentages, enti
     if(all(entity.counts == 0))
     {
         # expect empty.reason to be either "output" or "remove". NA shouldn't occur
-        if(is.na(empty.reason))
+        if(is.na(empty.extraction))
             stop("Unexpected output: Zero entities extracted with no reason specified.")
         else if(empty.extraction == "output")
             empty.reason <- ""

--- a/R/entityextractionwidget.R
+++ b/R/entityextractionwidget.R
@@ -44,7 +44,7 @@ EntityExtractionWidget <- function(entity.percentages, variant.percentages, enti
             empty.reason <- paste0("since the only entities in the output have been removed with the user specified",
                                    " remove entities from extraction settings.")
         else
-            stop("Unexpected output: Zero entities extracted with unexpected reason - ", empty.reason)
+            stop("Unexpected output: Zero entities extracted with unexpected reason - ", empty.extraction)
 
         user.empty.msg <- paste0("No entities found to extract from dataset ", empty.reason, "\n",
                                  "Use the 'Add named entities to extraction' control if you wish ",

--- a/R/entityextractionwidget.R
+++ b/R/entityextractionwidget.R
@@ -12,11 +12,13 @@
 #'     entity type in the named entity recognition detection.
 #' @param title The title to show at the top.
 #' @param footer Footer to show containing sample information.
+#' @param empty.extraction character giving the reason for a possible output with no entities. Returns
+#'   \code{NA} if entities extracted.
 #' @return An \code{htmlwidget} containing tables showing the output from an entity extraction.
 #' @seealso \code{\link[rhtmlMetro]{Box}}
 #' @export
 EntityExtractionWidget <- function(entity.percentages, variant.percentages, entity.counts,
-                                   variant.counts, title, footer)
+                                   variant.counts, title, footer, empty.extraction)
 {
     tfile <- createTempFile()
     cata <- createCata(tfile)
@@ -32,7 +34,15 @@ EntityExtractionWidget <- function(entity.percentages, variant.percentages, enti
          "</thead><tbody>")
 
     if(all(entity.counts == 0)) {
-        user.empty.msg <- paste0("No entities found to extract from dataset \n",
+        if(empty.extraction == "output")
+        {
+            empty.reason <- NULL
+        } else
+        {
+            empty.reason <- paste0("since the only entities in the output have been removed with the user specified",
+                                   " remove entities from extraction settings.")
+        }
+        user.empty.msg <- paste0("No entities found to extract from dataset ", empty.reason, "\n",
                                  "Use the 'Add named entities to extraction' control if you wish ",
                                  "to add entities to extract from the text.")
         cata("<tr class=\"table-row\"><td>")

--- a/man/EntityExtractionWidget.Rd
+++ b/man/EntityExtractionWidget.Rd
@@ -5,7 +5,7 @@
 \title{Display entity extraction output as an \code{htmlwidget}}
 \usage{
 EntityExtractionWidget(entity.percentages, variant.percentages,
-  entity.counts, variant.counts, title, footer)
+  entity.counts, variant.counts, title, footer, empty.extraction)
 }
 \arguments{
 \item{entity.percentages}{named numeric vector showing the percentage ocurrence of entity types
@@ -23,6 +23,9 @@ entity type in the named entity recognition detection.}
 \item{title}{The title to show at the top.}
 
 \item{footer}{Footer to show containing sample information.}
+
+\item{empty.extraction}{character giving the reason for a possible output with no entities. Returns
+\code{NA} if entities extracted.}
 }
 \value{
 An \code{htmlwidget} containing tables showing the output from an entity extraction.

--- a/tests/testthat/test-entityextractionwidget.R
+++ b/tests/testthat/test-entityextractionwidget.R
@@ -74,7 +74,7 @@ variant.counts = list(Number = c(I = 1, `11` = 1, one = 2, `90s` = 1, `80s` = 1,
                       Ideology = c(neutral = 1, `church of scientology` = 1),
                       City = c(Hollywood = 1))
 
-footer <- "Text was processed for Entity detection using 300 cases. There was 1 missing case."
+footer <- "Text was processed using 299 cases. There was 1 missing case."
 
 empty.output.table <- structure(list(id = structure(integer(0), .Label = character(0), class = "factor"),
                                      entity = structure(integer(0), .Label = character(0), class = "factor"),
@@ -91,7 +91,9 @@ test_that("Widget output check",
     result <- EntityExtractionWidget(entity.percentages, variant.percentages, entity.counts,
                                      variant.counts, title, footer)
     expect_is(result, "htmlwidget")
-    null.result <- EntityExtractionWidget(0, 0, 0, 0, title, footer)
+    null.result <- EntityExtractionWidget(0, 0, 0, 0, title, footer, "output")
+    expect_is(null.result, "htmlwidget")
+    null.result <- EntityExtractionWidget(0, 0, 0, 0, title, footer, "remove")
     expect_is(null.result, "htmlwidget")
 })
 


### PR DESCRIPTION
Give the user a feedback message in the widget if they attempt to extract entities but then remove them with the user settings.