### PR TITLE
DS 2710-2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.6.1
+Version: 1.6.2
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/textclassifierwidget.R
+++ b/R/textclassifierwidget.R
@@ -29,7 +29,7 @@ TextClassifierWidget <- function(observed.counts,
 {
     tfile <- createTempFile()
     cata <- createCata(tfile)
-    addCss("automaticcategorization.css", cata)
+    addCss("textclassifier.css", cata)
 
     cata("<div class=\"main-container\">")
 

--- a/inst/css/automaticcategorization.css
+++ b/inst/css/automaticcategorization.css
@@ -83,8 +83,7 @@ table.auto-categorization-table {
 
 .auto-categorization-table caption {
     padding-bottom: 4px;
-    padding-top: 8px;
-    margin-bottom: 0;
+    padding-top: 4px;
     caption-side:bottom;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     line-height: 1.42857143;

--- a/inst/css/details.css
+++ b/inst/css/details.css
@@ -9,6 +9,10 @@ summary {
     /* margin-bottom: 10px; */
 }
 
+.details {
+  max-height: 100%;
+}
+
 @supports (-ms-ime-align:auto) {
   .summary, .details {
       /* border-bottom: 3px solid #151A1C; */

--- a/inst/css/entityextraction.css
+++ b/inst/css/entityextraction.css
@@ -74,9 +74,8 @@ th {
 }
 
 .entity-extraction-table caption {
-    padding-bottom: 8px;
-    padding-top: 8px;
-    margin-bottom:5px;
+    padding-bottom: 4px;
+    padding-top: 4px;
     caption-side:bottom;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     line-height: 1.42857143;

--- a/inst/css/textanalysis.css
+++ b/inst/css/textanalysis.css
@@ -65,7 +65,7 @@
     text-align:left;
     width: 100%;
     padding-bottom: 4px;
-    padding-top: 3px;
+    padding-top: 4px;
     flex: 1 0 auto;
     overflow: auto;
 }

--- a/inst/css/textanalysis.css
+++ b/inst/css/textanalysis.css
@@ -10,7 +10,7 @@
 }
 
 .dummy-container {
-    flex: 1 0 0;
+    flex: 1000 0 0;
 }
 
 .vertical-container {
@@ -34,8 +34,8 @@
 }
 
 .top-container-diagnostic {
-    height: 100vh;
-    padding-top: 10px;
+    max-height: calc(100% - 2em - 4px);
+    padding-top: 4px;
 }
 
 .bottom-container {

--- a/inst/css/textanalysis.css
+++ b/inst/css/textanalysis.css
@@ -7,7 +7,6 @@
     align-items: flex-start;
     width: 100%;
     height: 100vh;
-    overflow: auto;
 }
 
 .dummy-container {
@@ -57,9 +56,7 @@
 }
 
 .footer-container {
-    height: auto;
-    min-height: 15px;
-    margin-bottom: 4px;
+    max-height: 20vh;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
     line-height: 1.42857143;
     color: #777;
@@ -68,11 +65,9 @@
     text-align:left;
     width: 100%;
     padding-bottom: 4px;
-    padding-top: 4px;
-}
-
-#footer {
-
+    padding-top: 3px;
+    flex: 1 0 auto;
+    overflow: auto;
 }
 
 #text-panel {

--- a/inst/css/textclassifier.css
+++ b/inst/css/textclassifier.css
@@ -83,7 +83,7 @@ table.auto-categorization-table {
 
 .auto-categorization-table caption {
     padding-bottom: 4px;
-    padding-top: 8px;
+    padding-top: 4px;
     margin-bottom: 0;
     caption-side:bottom;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/inst/css/textclassifier.css
+++ b/inst/css/textclassifier.css
@@ -94,16 +94,29 @@ table.auto-categorization-table {
     text-align:left;
 }
 
+
 .auto-categorization-table td:nth-of-type(1) {
-    width: calc(0vw);
+width: calc(0vw);
 }
 
 .auto-categorization-table td:nth-of-type(2) {
-    width: calc(30vw);
+width: calc(25vw);
 }
 
 .auto-categorization-table td:nth-of-type(3) {
-    width: calc(10vw);
+width: calc(13vw);
+}
+
+.auto-categorization-table td:nth-of-type(4) {
+width: calc(13vw);
+}
+
+.auto-categorization-table td:nth-of-type(5) {
+width: calc(13vw);
+}
+
+.auto-categorization-table td:nth-of-type(6) {
+width: calc(36vw);
 }
 
 .table-row {
@@ -134,4 +147,24 @@ table.auto-categorization-table {
 
 table.raw-text-table {
     border-bottom: 2px solid #dddddd;
+}
+
+
+.classifier-validation-table {
+display: flex;
+    justify-content: center;
+}
+
+.classifier-validation-table table {
+border-top: 2px solid #dddddd;
+    border-bottom: 2px solid #dddddd;
+    font-size: 11px;
+    color: #777;
+    font-style:italic;
+}
+
+.classifier-validation-table th {
+font-weight: normal;
+    border-bottom: 1px solid #dddddd;
+    padding: 3px;
 }

--- a/inst/css/textclassifier.css
+++ b/inst/css/textclassifier.css
@@ -151,12 +151,12 @@ table.raw-text-table {
 
 
 .classifier-validation-table {
-display: flex;
+    display: flex;
     justify-content: center;
 }
 
 .classifier-validation-table table {
-border-top: 2px solid #dddddd;
+    border-top: 2px solid #dddddd;
     border-bottom: 2px solid #dddddd;
     font-size: 11px;
     color: #777;
@@ -164,7 +164,7 @@ border-top: 2px solid #dddddd;
 }
 
 .classifier-validation-table th {
-font-weight: normal;
+    font-weight: normal;
     border-bottom: 1px solid #dddddd;
     padding: 3px;
 }


### PR DESCRIPTION
Improved widget outputs. 

1. Improved consistency in footer spacing between flipTextAnalysis outputs.
2. Added the functionality for a variable length footer to be automatically given the correct amount of space in  widgets that depend on textanalysis.css (List Categorization and wordBag). If the footer is less than 20% of the widget height, then it is given the minimum space it needs and the other parts of the widget expand into the remaining space. If the footer is more than 20% of the overall widget height, then it is given 20% of the space and a scroll bar is given to view the remaining text.
3. Split the AutomaticCategorization and TextClassifier widgets to each have their own css file. This was done to change the column widths for TextClassifier since it has more columns than AutomaticCategorization.