### PR TITLE
Allow horizontal resizing in textanalysis widgets [revdep skip]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.6.6
+Version: 1.6.7
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/inst/css/textanalysis.css
+++ b/inst/css/textanalysis.css
@@ -37,7 +37,9 @@ details[open] + .panel-container {
 }
 
 .ngrams-panel {
-    flex: 1 1 40%;
+    flex: 1 1 auto;
+    resize: horizontal;
+    max-width: calc(50vw);
 }
 
 .diagnostics-panel {


### PR DESCRIPTION
See the Displayr document https://app.displayr.com/Dashboard?project_id=-726291 to see the horizontal scrolling. In particular tabs labelled List Categorization and wordBag.