### PR TITLE
DS-2703

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
-  - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
+  - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev libnlopt-dev
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.6.11
+Version: 1.6.12
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/labels.R
+++ b/R/labels.R
@@ -57,6 +57,8 @@ Labels <- function(x, names.to.lookup = NULL, show.name = FALSE)
             return(label)
         if (!show.name | is.null(label))
             return(name)
+        if (is.null(name) & !is.null(label))
+            return(label)
         paste0(label, " (", name, ")")
     }
     # Single variable case.

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -103,6 +103,11 @@ test_that("Labels",
     z <- data.frame(a = 1:10, b = 1:10, c = 1:10)
     Labels(z) <- c("A", "B")
     expect_equal(as.character(Labels(z)), c("A","B", "c"))
+    # DS-2703 Data stacking creates a situation when a variable has a label but not a nem
+    # Return the label when name doesnt exist but Labels asks for it (flipRegression does this)
+    z <- c(1:2)
+    attr(z, "label") <- "C"
+    expect_equal(Labels(z, show.name = TRUE), "C")
 })
 
 


### PR DESCRIPTION
The new Stack data option in flipRegression creates an edge case whereby a the outcome variable set with a multi structure (many variables) is reduced down to a single outcome variable. From the backend and user perspective, the R object for the variable set is a question with a label but not a name (doesn't exist in the attributes). If an outcome variable is a factor but a numeric regression is used, then it is coerced to numeric and as part of the subsequent warning, the `Labels` function is called. It wants to create a string of the form `"label (name)"`. This labels function doesn't expect a scenario where a variable has a label but not a name and will return `"label ()"` as a result. The commit here fixes that edge case.