### PR TITLE
DS-83 Add dummy variable adjustment option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
-  - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
+  - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev libnlopt-dev
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.6.11
+Version: 1.6.12
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.6.12
+Version: 1.6.13
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/sampledescription.R
+++ b/R/sampledescription.R
@@ -20,12 +20,14 @@
 #' that typically appears in a footer.
 #' @param resample Whether resampling is used whenever weights are applied.
 #' @param effective.sample.size The effective sample size when weights are applied.
+#' @param dummy.adjusted Logical to determine if dummy variables have been used in the sample.
 #' @return character description of sample
 #' @export
 SampleDescription <- function(n.total, n.subset, n.estimation, subset.label, weighted = TRUE,
                               weight.label = "", missing, imputation.label = NULL, m,
                               variable.description = "", resample = FALSE,
-                              effective.sample.size = NULL)
+                              effective.sample.size = NULL,
+                              dummy.adjusted = FALSE)
 {
     # Warning if there is less than 50% data.
     missing.data.proportion <- if (n.subset)
@@ -45,14 +47,16 @@ SampleDescription <- function(n.total, n.subset, n.estimation, subset.label, wei
     if (variable.description != "")
         variable.description <- paste0(variable.description, " ")
     if (missing.data || (imputation && !is.null(imputation.label))) # imputation implies no missing data, NULL label if no missing data to impute
-        description <- paste(description, switch(missing,
+        description <- paste0(description, switch(missing,
                                                  "Error if missing data" = "",
-                                                 "Exclude cases with missing data" = "cases containing missing values have been excluded;",
-                                                 "Exclude cases with all missing data" = "cases containing all missing values have been excluded;",
+                                                 "Exclude cases with missing data" = " cases containing missing values have been excluded;",
+                                                 "Exclude cases with all missing data" = " cases containing all missing values have been excluded;",
                                                  "Imputation (replace missing values with estimates)" =
-                                                     paste0("missing values of ", variable.description, "variables have been imputed using ", imputation.label, ";"),
+                                                     paste0(" missing values of ", variable.description, "variables have been imputed using ", imputation.label, ";"),
                                                  "Multiple imputation" =
-                                                     paste0("multiple imputation (m = ", m, ", ", imputation.label, ") has been used to impute missing values of predictor variables;")))
+                                                     paste0(" multiple imputation (m = ", m, ", ", imputation.label, ") has been used to impute missing values of predictor variables;")))
+    if (dummy.adjusted)
+        description <- paste(description, paste0("missing values of ", variable.description, "variables have been adjusted using dummy variables;"))
     description
 }
 
@@ -97,4 +101,3 @@ BaseDescription <- function(description.of.n, n.total, n.subset, n.estimation, s
         ""
     paste0(description.of.n, base, ";", weight.text, ess.text)
 }
-

--- a/man/SampleDescription.Rd
+++ b/man/SampleDescription.Rd
@@ -16,7 +16,8 @@ SampleDescription(
   m,
   variable.description = "",
   resample = FALSE,
-  effective.sample.size = NULL
+  effective.sample.size = NULL,
+  dummy.adjusted = FALSE
 )
 }
 \arguments{
@@ -49,6 +50,8 @@ that typically appears in a footer.}
 \item{resample}{Whether resampling is used whenever weights are applied.}
 
 \item{effective.sample.size}{The effective sample size when weights are applied.}
+
+\item{dummy.adjusted}{Logical to determine if dummy variables have been used in the sample.}
 }
 \value{
 character description of sample

--- a/tests/testthat/test-sampledescription.R
+++ b/tests/testthat/test-sampledescription.R
@@ -19,3 +19,54 @@ test_that("Effective sample size", {
                 "data has been weighted (wgt); effective sample size: 127.07; ",
                 "cases containing missing values have been excluded;"))})
 
+test_that("Missing value strings", {
+    n.tot <- 123
+    n.sub <- 123
+    n.est <- 100
+    # Missing data excluded
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Exclude cases with missing data"),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, "; ",
+                        "cases containing missing values have been excluded;"))
+    # Error if missing
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Error if missing data"),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, ";"))
+    # Single imputation
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Imputation (replace missing values with estimates)",
+                                   imputation.label = "chained equations (predictive mean matching)",
+                                   variable.description = "predictor"),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, "; ",
+                        "missing values of predictor variables have been imputed using chained equations ",
+                        "(predictive mean matching);"))
+    # Multiple imputation
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Multiple imputation", m = 2,
+                                   imputation.label = "chained equations (predictive mean matching)",
+                                   variable.description = "predictor"),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, "; ",
+                        "multiple imputation (m = 2, chained equations (predictive mean matching)) has been ",
+                        "used to impute missing values of predictor variables;"))
+    # Dummy variable adjustment selected but no dummy variables created. No dummy variable message
+    # should appear in footer
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Dummy variable adjustment",
+                                   dummy.adjusted = FALSE),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, ";"))
+    # Expect dummy variable adjustment method message to appear
+    expect_equal(SampleDescription(n.total = n.tot, n.subset = n.sub,
+                                   weighted = FALSE, n.estimation = n.est,
+                                   missing = "Dummy variable adjustment",
+                                   dummy.adjusted = TRUE),
+                 paste0("n = ", n.est, " cases used in estimation of a total sample size of ", n.sub, "; ",
+                        "missing values of variables have been adjusted using dummy variables;"))
+
+
+})
+


### PR DESCRIPTION
Dummy variable adjustment option has been added to the missing data
outputs in regression and needs to be communicated in the output widgets
via SampleDescription.

Tests updated to validate the use of missing variable techniques.