### PR TITLE
RS-13510: fix spacing in empty cells

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.10.8
+Version: 1.10.9
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/createcustomtable.R
+++ b/R/createcustomtable.R
@@ -334,9 +334,12 @@ CreateCustomTable = function(x,
                else                                  FormatAsReal(x, decimals = format.decimals)
     content <- matrix(paste0(cell.prefix, content, cell.suffix), nrows, ncols)
     if (suppress.nan)
-        content[which(is.nan(x))] <- ""
+        content[which(is.nan(x))] <- "<br>"
     if (suppress.na)
-        content[which(is.na(x) & !is.nan(x))] <- ""
+        content[which(is.na(x) & !is.nan(x))] <- "<br>"
+    ind.empty <- which(!nzchar(content))
+    if (any(ind.empty))
+        content[ind.empty] <- "<br>"
     if (is.character(x))
     {
         # check image tags and remove and warn for invalid urls


### PR DESCRIPTION
So autofit table doesn't look like this: 
![image](https://user-images.githubusercontent.com/2977281/226494086-41177602-dfc6-4980-8046-58d57e331392.png)
