### PR TITLE
DS-5301: Fix dataset merging by case widget if mergesrc var. is not last

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
   executor:
     type: enum
     enum: [nightly, rocker, machine]
-    default: rocker
+    default: nightly
 
 workflows:
   build-and-check-R-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ parameters:
     type: enum
     enum: [nightly, rocker, machine]
     default: nightly
+  save-snapshots:
+    type: boolean
+    default: true    
 
 workflows:
   build-and-check-R-package:
@@ -26,9 +29,10 @@ workflows:
           executor: << pipeline.parameters.executor >>
           name: BuildAndCheckPackage
           context:
-            - r_packages
+            - rviz_packages
           remote-deps: << pipeline.parameters.remote-deps >>
           separate-test-job: false
+          save-snapshots: << pipeline.parameters.save-snapshots >>
       - r-packages/deploy-package:
           executor: << pipeline.parameters.executor >>
           requires:

--- a/R/datasetmergingbycasewidget.R
+++ b/R/datasetmergingbycasewidget.R
@@ -94,7 +94,7 @@ DataSetMergingByCaseWidget <- function(input.data.sets.metadata,
         var.type <- variableTypeConverter(merged.data.set.metadata$variable.types[i])
         merged.val.attr <- merged.data.set.metadata$variable.value.attributes[[i]]
 
-        if (i < n.vars) # not the mergesrc variable
+        if (!identical(names(var.label), "mergesrc"))
         {
             input.var.ind <- vapply(seq_len(n.data.sets), function(j) {
                 match(matched.names[i, j], input.data.sets.metadata$variable.names[[j]])

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Displayr/flipFormat/badge.svg?branch=master)](https://coveralls.io/github/Displayr/flipFormat?branch=master)
 # flipFormat
 
-Formatting of R outputs
+Tools for summarizing various Advanced Analysis, Calculation, and Table outputs in Displayr as interactive htmlwidgets
 
 ## Installation
 

--- a/tests/testthat/test-datasetmergingbycasewidget.R
+++ b/tests/testthat/test-datasetmergingbycasewidget.R
@@ -149,5 +149,5 @@ test_that("Too many variables to fit in a page", {
 
 test_that("DS-5301: Widget creation works if one input dataset already has a mergeSrc variable", 
 {
-    expect_error(print(merge.output.existing.mergesrc), NA)
+    expect_error(print(merge.output.existing.mergesrc)), NA)
 }

--- a/tests/testthat/test-datasetmergingbycasewidget.R
+++ b/tests/testthat/test-datasetmergingbycasewidget.R
@@ -149,5 +149,5 @@ test_that("Too many variables to fit in a page", {
 
 test_that("DS-5301: Widget creation works if one input dataset already has a mergeSrc variable", 
 {
-    expect_error(print(merge.output.existing.mergesrc)), NA)
-}
+    expect_error(print(merge.output.existing.mergesrc), NA)
+})

--- a/tests/testthat/test-datasetmergingbycasewidget.R
+++ b/tests/testthat/test-datasetmergingbycasewidget.R
@@ -83,9 +83,9 @@ test_that("Pagination", {
                                          page = 2,
                                          variables.per.page = 10)
 
-    if (identical(Sys.getenv("TRAVIS"), "true"))
+    if (identical(Sys.getenv("CIRCLECI"), "true"))
     {
-        print("Comparing snapshot on travis")
+        print("Comparing snapshot on Circle-CI")
         expect_true(TestWidget(widget, "merging-by-case-widget-page-2", height = 800))
     }
 })
@@ -100,9 +100,9 @@ test_that("Too many variables to fit in a page", {
                                          merge.data.set.output$is.saved.to.cloud,
                                          variables.per.page = 10)
 
-    if (identical(Sys.getenv("TRAVIS"), "true"))
+    if (identical(Sys.getenv("CIRCLECI"), "true"))
     {
-        print("Comparing snapshot on travis")
+        print("Comparing snapshot on Circle-CI")
         expect_true(TestWidget(widget, "merging-by-case-widget-warning", height = 800))
     }
 })

--- a/tests/testthat/test-datasetmergingbycasewidget.R
+++ b/tests/testthat/test-datasetmergingbycasewidget.R
@@ -11,6 +11,46 @@ findInstDirFile <- function(file)
 
 load(findInstDirFile("merge.data.set.output.rda"))
 
+## merge.output.existing.mergesrc, which is used for testing DS-5301, can be recreated with the
+## following code. We include the dput output here to avoid installing/calling flipData
+## df1 <- data.frame(x=1:2, mergesrc= as.factor(c('a', 'b')))
+## df2 <- data.frame(x=2:3, z = c('a', 'b'))
+## file1 <- tempfile(fileext = ".sav")
+## file2 <- tempfile(fileext = ".sav")
+## outfile <- "foo.sav"  # MergeDataSetsByCase complains if special chars. in filename
+## haven::write_sav(df1, file1)
+## haven::write_sav(df2, file2)
+## result <- MergeDataSetsByCase(c(file1, file2), outfile)
+merge.output.existing.mergesrc <- structure(list(input.data.sets.metadata = list(variable.names.list = list(
+    file45c053d64f11.sav = c("x", "mergesrc"), file45c01f0a608f.sav = c("x", 
+    "z")), variable.labels.list = list(file45c053d64f11.sav = c(x = "", 
+mergesrc = ""), file45c01f0a608f.sav = c(x = "", z = "")), variable.value.attributes.list = list(
+    file45c053d64f11.sav = list(x = NULL, mergesrc = c(a = 1, 
+    b = 2)), file45c01f0a608f.sav = list(x = NULL, z = NULL)), 
+    variable.types.list = list(file45c053d64f11.sav = c(x = "Numeric", 
+    mergesrc = "Categorical"), file45c01f0a608f.sav = c(x = "Numeric", 
+    z = "Text")), n.data.sets = 2L, n.cases = c(file45c053d64f11.sav = 2L, 
+    file45c01f0a608f.sav = 2L), data.set.names = c("file45c053d64f11.sav", 
+    "file45c01f0a608f.sav")), merged.data.set.metadata = list(
+    variable.names = c("x", "mergesrc", "z"), variable.labels = c(x = "", 
+    mergesrc = "Source of cases", z = ""), variable.value.attributes = list(
+        x = NULL, mergesrc = structure(1:3, names = c("a", "b", 
+        "file45c01f0a608f.sav")), z = NULL), variable.types = c(x = "Numeric", 
+    mergesrc = "Categorical", z = "Text"), n.variables = 3L, 
+    n.cases = 4L, data.set.name = "foo.sav"), matched.names = structure(c("x", 
+"mergesrc", NA, "x", NA, "z"), dim = 3:2, is.fuzzy.match = structure(c(FALSE, 
+FALSE, FALSE, FALSE, FALSE, FALSE), dim = 3:2), matched.by = structure(c(NA, 
+NA, NA, "Variable name", NA, NA), dim = 3:2), match.parameters = list(
+    auto.select.what.to.match.by = TRUE, match.by.variable.names = TRUE, 
+    match.by.variable.labels = FALSE, match.by.value.labels = TRUE, 
+    ignore.case = TRUE, ignore.non.alphanumeric = TRUE, min.match.percentage = 90, 
+    min.value.label.match.percentage = 90)), merged.names = structure(c("x", 
+"mergesrc", "z"), renamed.variables = structure(character(0), dim = c(0L, 
+2L), dimnames = list(NULL, c("Original name", "New name")))), 
+    omitted.variable.names.list = list(character(0), character(0)), 
+    input.value.attributes.list = list(x = NULL, mergesrc = NULL, 
+        z = NULL), is.saved.to.cloud = FALSE), class = "MergeDataSetByCase")
+
 test_that("Data set merging by case widget", {
     expect_error(widget <- DataSetMergingByCaseWidget(merge.data.set.output$input.data.sets.metadata,
                                                       merge.data.set.output$merged.data.set.metadata,
@@ -107,3 +147,7 @@ test_that("Too many variables to fit in a page", {
     }
 })
 
+test_that("DS-5301: Widget creation works if one input dataset already has a mergeSrc variable", 
+{
+    expect_error(print(merge.output.existing.mergesrc), NA)
+}


### PR DESCRIPTION
* When the second dataset contains a variable not in the first, the "mergesrc" variable no longer appears last in the data.