### PR TITLE
DS-4008: Improve highlighting in DataSetMergingByCase widget

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipFormat
 Type: Package
 Title: Formatting of R outputs
-Version: 1.11.1
+Version: 1.11.2
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Formatting to be used in print statements and other outputs. E.g.,

--- a/R/datasetmergingbycasewidget.R
+++ b/R/datasetmergingbycasewidget.R
@@ -424,11 +424,12 @@ valueAttributesTable <- function(merged.val.attr, input.data.sets.metadata,
         result <- paste0(result, "<tr><td>",
                          htmlText(names(merged.val.attr)[j]),
                          "</td><td>", htmlText(merged.val.attr[j]), "</td>")
-
+        missing.from.all.data.sets <- TRUE
         for (k in seq_len(n.data.sets))
         {
             result <- if (!is.na(input.val.attr.list[[k]][j]))
             {
+                missing.from.all.data.sets <- FALSE
                 val <- input.val.attr.list[[k]][j]
 
                 if (input.var.types[[k]][input.var.ind[k]] %in% cat.types)
@@ -459,7 +460,11 @@ valueAttributesTable <- function(merged.val.attr, input.data.sets.metadata,
                 }
             }
             else # Missing value
+            {
+                if (!missing.from.all.data.sets)
+                    is.summary.highlighted <- TRUE
                 paste0(result, "<td>-</td>")
+            }
         }
         result <- paste0(result, "</tr>")
     }


### PR DESCRIPTION
* When a merged variable value is missing from some of the input data sets, the variable will now be flagged in `valueAttributesTable` as needing to be highlighted in the output widget