### PR TITLE
DPI-2856 Package flipFormat in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipFormat";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Formatting to be used in print statements and other outputs. E.g.,
+    number formatting, formatting of tables.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    xml2
+    janitor
+    sparkline
+    htmlwidgets
+    DT
+    colorspace
+    httr
+    rmarkdown
+    rhtmlMetro
+    flipU
+    stringr
+    stringi
+    formattable
+    htmltools
+    knitr
+    striprtf
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipFormat in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR